### PR TITLE
Forward Exponax Release

### DIFF
--- a/apebench/_base_scenario.py
+++ b/apebench/_base_scenario.py
@@ -777,7 +777,7 @@ class BaseScenario(eqx.Module, ABC):
     def perform_test_rollout(
         self,
         neural_stepper: eqx.Module,
-        mean_error_fn: Callable = ex.metrics.mean_nRMSE,
+        error_fn: Callable = ex.metrics.nRMSE,
     ) -> Float[Array, "test_temporal_horizon"]:
         """
         Rollout the neural stepper starting from the test initial condition and
@@ -795,7 +795,7 @@ class BaseScenario(eqx.Module, ABC):
         )(test_ics)
 
         error_rollout = jax.vmap(
-            mean_error_fn,
+            lambda pred, ref: ex.metrics.mean_metric(error_fn, pred, ref),
             in_axes=1,  # over the temporal axis
         )(pred_trjs, ref_trjs)
 

--- a/apebench/scenarios/difficulty/_convection.py
+++ b/apebench/scenarios/difficulty/_convection.py
@@ -27,7 +27,7 @@ class Convection(BaseScenario):
         substepped_gammas = tuple(g / self.num_substeps for g in gammas)
         substepped_delta = delta / self.num_substeps
 
-        substepped_stepper = ex.normalized.DifficultyConvectionStepper(
+        substepped_stepper = ex.stepper.generic.DifficultyConvectionStepper(
             self.num_spatial_dims,
             self.num_points,
             linear_difficulties=substepped_gammas,

--- a/apebench/scenarios/difficulty/_convection.py
+++ b/apebench/scenarios/difficulty/_convection.py
@@ -10,6 +10,7 @@ from ..._base_scenario import BaseScenario
 class Convection(BaseScenario):
     gammas: tuple[float, ...] = (0.0, 0.0, 1.5, 0.0, 0.0)
     convection_delta: float = -1.5
+    conservative: bool = True
 
     num_substeps: int = 1
 
@@ -33,6 +34,7 @@ class Convection(BaseScenario):
             linear_difficulties=substepped_gammas,
             # Need minus to move the convection to the right hand side
             convection_difficulty=-substepped_delta,
+            conservative=self.conservative,
             order=self.order,
             dealiasing_fraction=self.dealiasing_fraction,
             num_circle_points=self.num_circle_points,

--- a/apebench/scenarios/difficulty/_linear.py
+++ b/apebench/scenarios/difficulty/_linear.py
@@ -8,17 +8,17 @@ class Linear(BaseScenario):
     coarse_proportion: float = 0.5
 
     def get_ref_stepper(self):
-        return ex.normalized.DifficultyLinearStepper(
+        return ex.stepper.generic.DifficultyLinearStepper(
             num_spatial_dims=self.num_spatial_dims,
             num_points=self.num_points,
-            difficulties=self.gammas,
+            linear_difficulties=self.gammas,
         )
 
     def get_coarse_stepper(self) -> ex.BaseStepper:
-        return ex.normalized.DifficultyLinearStepper(
+        return ex.stepper.generic.DifficultyLinearStepper(
             num_spatial_dims=self.num_spatial_dims,
             num_points=self.num_points,
-            difficulties=tuple(f * self.coarse_proportion for f in self.gammas),
+            linear_difficulties=tuple(f * self.coarse_proportion for f in self.gammas),
         )
 
     def get_scenario_name(self) -> str:

--- a/apebench/scenarios/difficulty/_nonlinear.py
+++ b/apebench/scenarios/difficulty/_nonlinear.py
@@ -34,7 +34,7 @@ class Nonlinear(BaseScenario):
         substepped_gammas = tuple(g / self.num_substeps for g in gammas)
         substepped_deltas = tuple(d / self.num_substeps for d in deltas)
 
-        substepped_stepper = ex.normalized.DifficultyGeneralNonlinearStepper(
+        substepped_stepper = ex.stepper.generic.DifficultyNonlinearStepper(
             num_spatial_dims=self.num_spatial_dims,
             num_points=self.num_points,
             linear_difficulties=substepped_gammas,

--- a/apebench/scenarios/normalized/_convection.py
+++ b/apebench/scenarios/normalized/_convection.py
@@ -6,6 +6,7 @@ from ..._base_scenario import BaseScenario
 class Convection(BaseScenario):
     alphas: tuple[float, ...] = (0.0, 0.0, 3.0e-5, 0.0, 0.0)
     convection_beta: float = -1.25e-2
+    conservative: bool = True
 
     num_substeps: int = 1
 
@@ -29,6 +30,7 @@ class Convection(BaseScenario):
             normalized_linear_coefficients=substepped_alphas,
             # Need minus to move the convection to the right hand side
             normalized_convection_scale=-substepped_convection,
+            conservative=self.conservative,
             order=self.order,
             dealiasing_fraction=self.dealiasing_fraction,
             num_circle_points=self.num_circle_points,

--- a/apebench/scenarios/normalized/_convection.py
+++ b/apebench/scenarios/normalized/_convection.py
@@ -23,10 +23,10 @@ class Convection(BaseScenario):
         substepped_convection = convection / self.num_substeps
         substepped_alphas = tuple(a / self.num_substeps for a in alphas)
 
-        substepped_stepper = ex.normalized.NormalizedConvectionStepper(
+        substepped_stepper = ex.stepper.generic.NormalizedConvectionStepper(
             self.num_spatial_dims,
             self.num_points,
-            normalized_coefficients=substepped_alphas,
+            normalized_linear_coefficients=substepped_alphas,
             # Need minus to move the convection to the right hand side
             normalized_convection_scale=-substepped_convection,
             order=self.order,

--- a/apebench/scenarios/normalized/_linear.py
+++ b/apebench/scenarios/normalized/_linear.py
@@ -8,17 +8,17 @@ class Linear(BaseScenario):
     coarse_proportion: float = 0.5
 
     def get_ref_stepper(self):
-        return ex.normalized.NormalizedLinearStepper(
+        return ex.stepper.generic.NormalizedLinearStepper(
             num_spatial_dims=self.num_spatial_dims,
             num_points=self.num_points,
-            normalized_coefficients=self.alphas,
+            normalized_linear_coefficients=self.alphas,
         )
 
     def get_coarse_stepper(self) -> ex.BaseStepper:
-        return ex.normalized.NormalizedLinearStepper(
+        return ex.stepper.generic.NormalizedLinearStepper(
             num_spatial_dims=self.num_spatial_dims,
             num_points=self.num_points,
-            normalized_coefficients=tuple(
+            normalized_linear_coefficients=tuple(
                 f * self.coarse_proportion for f in self.alphas
             ),
         )

--- a/apebench/scenarios/normalized/_nonlinear.py
+++ b/apebench/scenarios/normalized/_nonlinear.py
@@ -28,11 +28,11 @@ class Nonlinear(BaseScenario):
         substepped_alphas = tuple(a / self.num_substeps for a in alphas)
         substepped_betas = tuple(b / self.num_substeps for b in betas)
 
-        substepped_stepper = ex.normalized.NormlizedGeneralNonlinearStepper(
+        substepped_stepper = ex.stepper.generic.NormalizedNonlinearStepper(
             num_spatial_dims=self.num_spatial_dims,
             num_points=self.num_points,
-            normalized_coefficients_linear=substepped_alphas,
-            normalized_coefficients_nonlinear=substepped_betas,
+            normalized_linear_coefficients=substepped_alphas,
+            normalized_nonlinear_coefficients=substepped_betas,
             order=self.order,
             dealiasing_fraction=self.dealiasing_fraction,
             num_circle_points=self.num_circle_points,

--- a/apebench/scenarios/physical/_convection.py
+++ b/apebench/scenarios/physical/_convection.py
@@ -9,6 +9,7 @@ class Convection(BaseScenario):
 
     a_coefs: tuple[float, ...] = (0.0, 0.0, 0.0003, 0.0, 0.0)
     convection_coef: float = -0.125
+    conservative: bool = True
 
     num_substeps: int = 1
 
@@ -31,6 +32,7 @@ class Convection(BaseScenario):
             linear_coefficients=self.a_coefs,
             # Need minus to move the convection to the right hand side
             convection_scale=-self.convection_coef,
+            conservative=self.conservative,
             order=self.order,
             dealiasing_fraction=self.dealiasing_fraction,
             num_circle_points=self.num_circle_points,

--- a/apebench/scenarios/physical/_convection.py
+++ b/apebench/scenarios/physical/_convection.py
@@ -23,12 +23,12 @@ class Convection(BaseScenario):
         self.num_channels = self.num_spatial_dims  # Overwrite
 
     def _build_stepper(self, dt):
-        substepped_stepper = ex.stepper.GeneralConvectionStepper(
+        substepped_stepper = ex.stepper.generic.GeneralConvectionStepper(
             num_spatial_dims=self.num_spatial_dims,
             domain_extent=self.domain_extent,
             num_points=self.num_points,
             dt=dt / self.num_substeps,
-            coefficients=self.a_coefs,
+            linear_coefficients=self.a_coefs,
             # Need minus to move the convection to the right hand side
             convection_scale=-self.convection_coef,
             order=self.order,

--- a/apebench/scenarios/physical/_gray_scott.py
+++ b/apebench/scenarios/physical/_gray_scott.py
@@ -37,7 +37,7 @@ class GrayScott(BaseScenario):
         )
 
     def _build_stepper(self, dt):
-        substepped_stepper = ex.reaction.GrayScott(
+        substepped_stepper = ex.stepper.reaction.GrayScott(
             num_spatial_dims=self.num_spatial_dims,
             domain_extent=self.domain_extent,
             num_points=self.num_points,
@@ -177,7 +177,7 @@ class GrayScottType(BaseScenario):
 
     def _build_stepper(self, dt):
         feed_rate, kill_rate = self.get_feed_and_kill_rate(self.pattern_type)
-        substepped_stepper = ex.reaction.GrayScott(
+        substepped_stepper = ex.stepper.reaction.GrayScott(
             num_spatial_dims=self.num_spatial_dims,
             domain_extent=self.domain_extent,
             num_points=self.num_points,

--- a/apebench/scenarios/physical/_linear.py
+++ b/apebench/scenarios/physical/_linear.py
@@ -11,21 +11,21 @@ class Linear(BaseScenario):
     coarse_proportion: float = 0.5
 
     def get_ref_stepper(self):
-        return ex.stepper.GeneralLinearStepper(
+        return ex.stepper.generic.GeneralLinearStepper(
             num_spatial_dims=self.num_spatial_dims,
             domain_extent=self.domain_extent,
             num_points=self.num_points,
             dt=self.dt,
-            coefficients=self.a_coefs,
+            linear_coefficients=self.a_coefs,
         )
 
     def get_coarse_stepper(self) -> ex.BaseStepper:
-        return ex.stepper.GeneralLinearStepper(
+        return ex.stepper.generic.GeneralLinearStepper(
             num_spatial_dims=self.num_spatial_dims,
             domain_extent=self.domain_extent,
             num_points=self.num_points,
             dt=self.dt * self.coarse_proportion,
-            coefficients=self.a_coefs,
+            linear_coefficients=self.a_coefs,
         )
 
     def get_scenario_name(self) -> str:

--- a/apebench/scenarios/physical/_nonlinear.py
+++ b/apebench/scenarios/physical/_nonlinear.py
@@ -28,13 +28,13 @@ class Nonlinear(BaseScenario):
         pass
 
     def _build_stepper(self, dt):
-        substepped_stepper = ex.stepper.GeneralNonlinearStepper(
+        substepped_stepper = ex.stepper.generic.GeneralNonlinearStepper(
             num_spatial_dims=self.num_spatial_dims,
             domain_extent=self.domain_extent,
             num_points=self.num_points,
             dt=dt / self.num_substeps,
-            coefficients_linear=self.a_coefs,
-            coefficients_nonlinear=self.b_coefs,
+            linear_coefficients=self.a_coefs,
+            nonlinear_coefficients=self.b_coefs,
             order=self.order,
             dealiasing_fraction=self.dealiasing_fraction,
             num_circle_points=self.num_circle_points,

--- a/apebench/scenarios/physical/_polynomial.py
+++ b/apebench/scenarios/physical/_polynomial.py
@@ -23,13 +23,13 @@ class Polynomial(BaseScenario):
         pass
 
     def _build_stepper(self, dt):
-        substepped_stepper = ex.stepper.GeneralPolynomialStepper(
+        substepped_stepper = ex.stepper.generic.GeneralPolynomialStepper(
             num_spatial_dims=self.num_spatial_dims,
             domain_extent=self.domain_extent,
             num_points=self.num_points,
             dt=dt / self.num_substeps,
-            coefficients=self.a_coefs,
-            polynomial_scales=self.poly_coefs,
+            linear_coefficients=self.a_coefs,
+            polynomial_coefficients=self.poly_coefs,
             order=self.order,
             dealiasing_fraction=self.dealiasing_fraction,
             num_circle_points=self.num_circle_points,

--- a/apebench/scenarios/physical/_swift_hohenberg.py
+++ b/apebench/scenarios/physical/_swift_hohenberg.py
@@ -22,14 +22,14 @@ class SwiftHohenberg(BaseScenario):
             raise ValueError("Swift-Hohenberg is only supported for 2D and 3D")
 
     def _build_stepper(self, dt):
-        substepped_stepper = ex.reaction.SwiftHohenberg(
+        substepped_stepper = ex.stepper.reaction.SwiftHohenberg(
             num_spatial_dims=self.num_spatial_dims,
             domain_extent=self.domain_extent,
             num_points=self.num_points,
             dt=dt / self.num_substeps,
             reactivity=self.reactivity,
             critical_number=self.critical_number,
-            polynomial_coefficients=self.polynomial_coefficients,
+            polynomial_linear_coefficients=self.polynomial_coefficients,
         )
 
         if self.num_substeps == 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "matplotlib>=3.8.1",
   "pandas>=2.2.0",
   "seaborn>=0.13.0",
-  "exponax==0.0.1",
+  "exponax>=0.1.0",
   "pdequinox==0.1.2",
   "trainax==0.0.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "matplotlib>=3.8.1",
   "pandas>=2.2.0",
   "seaborn>=0.13.0",
-  "exponax>=0.1.0",
+  "exponax==0.1.0",
   "pdequinox==0.1.2",
   "trainax==0.0.2",
 ]

--- a/tests/test_builtin_scenarios.py
+++ b/tests/test_builtin_scenarios.py
@@ -38,7 +38,7 @@ def test_builtin_scenarios(name: str):
 def test_simple_training(name: str, num_spatial_dims: int):
     NUM_TRAIN_SAMPLES = 5
     NUM_TEST_SAMPLES = 5
-    NUM_POINTS = 40
+    NUM_POINTS = 15
     OPTIM_CONFIG = "adam;10;constant;1e-4"
 
     # Some scenarios might not work in 1d, (which is the default number of spatial dims)

--- a/tests/test_builtin_scenarios.py
+++ b/tests/test_builtin_scenarios.py
@@ -25,7 +25,11 @@ def test_builtin_scenarios(name: str):
 
 @pytest.mark.parametrize(
     "name",
-    list(apebench.scenarios.scenario_dict.keys()),
+    [
+        "phy_adv",
+        "norm_adv",
+        "diff_adv",
+    ],
 )
 def test_simple_training_1d(name: str):
     NUM_TRAIN_SAMPLES = 5

--- a/tests/test_builtin_scenarios.py
+++ b/tests/test_builtin_scenarios.py
@@ -21,3 +21,31 @@ def test_builtin_scenarios(name: str):
     ref = scene.get_ref_sample_data()
 
     del ref
+
+
+@pytest.mark.parametrize(
+    "name",
+    list(apebench.scenarios.scenario_dict.keys()),
+)
+def test_simple_training_1d(name: str):
+    NUM_TRAIN_SAMPLES = 5
+    NUM_TEST_SAMPLES = 5
+    OPTIM_CONFIG = "adam;10;constant;1e-4"
+
+    # Some scenarios might not work in 1d, (which is the default number of spatial dims)
+    try:
+        scene = apebench.scenarios.scenario_dict[name](
+            num_train_samples=NUM_TRAIN_SAMPLES,
+            num_test_samples=NUM_TEST_SAMPLES,
+            optim_config=OPTIM_CONFIG,
+        )
+    except ValueError:
+        return
+
+    NETWORK_CONFIG = "Conv;10;2;relu"
+
+    data, trained_net = scene(
+        network_config=NETWORK_CONFIG,
+    )
+
+    del data, trained_net

--- a/tests/test_builtin_scenarios.py
+++ b/tests/test_builtin_scenarios.py
@@ -24,23 +24,30 @@ def test_builtin_scenarios(name: str):
 
 
 @pytest.mark.parametrize(
-    "name",
+    "name,num_spatial_dims",
     [
-        "phy_adv",
-        "norm_adv",
-        "diff_adv",
+        (name, num_spatial_dims)
+        for name in [
+            "phy_adv",
+            "norm_adv",
+            "diff_adv",
+        ]
+        for num_spatial_dims in [1, 2, 3]
     ],
 )
-def test_simple_training_1d(name: str):
+def test_simple_training(name: str, num_spatial_dims: int):
     NUM_TRAIN_SAMPLES = 5
     NUM_TEST_SAMPLES = 5
+    NUM_POINTS = 40
     OPTIM_CONFIG = "adam;10;constant;1e-4"
 
     # Some scenarios might not work in 1d, (which is the default number of spatial dims)
     try:
         scene = apebench.scenarios.scenario_dict[name](
+            num_spatial_dims=num_spatial_dims,
             num_train_samples=NUM_TRAIN_SAMPLES,
             num_test_samples=NUM_TEST_SAMPLES,
+            num_points=NUM_POINTS,
             optim_config=OPTIM_CONFIG,
         )
     except ValueError:

--- a/tests/test_builtin_scenarios.py
+++ b/tests/test_builtin_scenarios.py
@@ -1,4 +1,4 @@
-# import pytest
+import pytest
 
 import apebench
 
@@ -7,17 +7,17 @@ def test_simple():
     apebench.scenarios.difficulty.Advection()
 
 
-# @pytest.mark.parametrize(
-#     "name",
-#     list(apebench.scenarios.scenario_dict.keys()),
-# )
-# def test_builtin_scenarios(name: str):
-#     # Some scenarios might not work in 1d, (which is the default number of spatial dims)
-#     try:
-#         scene = apebench.scenarios.scenario_dict[name]()
-#     except ValueError:
-#         return
+@pytest.mark.parametrize(
+    "name",
+    list(apebench.scenarios.scenario_dict.keys()),
+)
+def test_builtin_scenarios(name: str):
+    # Some scenarios might not work in 1d, (which is the default number of spatial dims)
+    try:
+        scene = apebench.scenarios.scenario_dict[name]()
+    except ValueError:
+        return
 
-#     ref = scene.get_ref_sample_data()
+    ref = scene.get_ref_sample_data()
 
-#     del ref
+    del ref


### PR DESCRIPTION
Updates to `Exponax 0.1.0` and forward all API changes.

Since Exponax [changed some internals](https://github.com/Ceyron/exponax/pull/59), this can affect some benchmarks. The most important changes are:

1. Change in the metric system (normalized metrics now normalized **per** channel and not over all channels)
2. Convection Nonlinearity changed to a non-conservative form by default ($b_1 \frac{1}{2} \nabla \cdot (u \otimes u) \rightarrow b_1 (u \cdot \nabla) u$), but the old "conservative" version is still available. I decided to keep it as the default in APEBench via setting the `conservative=True` for all steppers using convection. This is to ensure legacy compatibility
3. For efficiency, Substeppers [now operate in Fourier space](https://github.com/Ceyron/exponax/pull/59). Qualitatively, this should not alter produced trajectories but can cause numeric differences, especially for chaotic problems (KS, etc.). This can slightly alter benchmark runs numeric results. To avoid the influence of the concrete dataset, consider rerunning benchmark runs with different train and test seeds.